### PR TITLE
repo.pp: fix duplicate variable assignment

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -40,7 +40,7 @@ define aptly::repo(
   $comment_arg = if $comment {
     "-comment=\"${comment}\""
   } else {
-    $comment_arg = ''
+    ''
   }
 
   $component_arg = if $component {


### PR DESCRIPTION
This was broken in https://github.com/voxpupuli/puppet-aptly/commit/40bdf883dbd78ce8976339e08e4473a5213f6d64

labeling as skip-changelog because the commit that introduced this isn't released yet.