### PR TITLE
Update repo.aptly.info gpg key

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,7 +60,7 @@ class aptly (
       repos    => 'main',
       key      => {
         server => $key_server,
-        id     => 'EE727D4449467F0E',
+        id     => '78D6517AB92E22947F577996A0546A43624A8331',
       },
     }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -72,7 +72,7 @@ describe 'aptly' do
         is_expected.to contain_apt__source('aptly').with(
           key: {
             'server' => 'keyserver.ubuntu.com',
-            'id' => 'EE727D4449467F0E'
+            'id' => '78D6517AB92E22947F577996A0546A43624A8331'
           }
         )
       end


### PR DESCRIPTION
according to the website the new key is 78D6517AB92E22947F577996A0546A43624A8331

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
