### PR TITLE
CI: Setup correct keyring for Perforce repos

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -8,6 +8,10 @@ case [$facts.get('os.name'), $facts.get('os.distro.release.major')] {
       location => 'http://apt.puppet.com',
       release  => 'bullseye',
       repos    => 'puppet-tools',
+      key      => {
+        'source' => 'https://apt.puppet.com/keyring.gpg',
+        'name'   => 'puppet.gpg',
+      },
       before   => Package['puppet-bolt'],
     }
   }
@@ -16,6 +20,10 @@ case [$facts.get('os.name'), $facts.get('os.distro.release.major')] {
       location => 'http://apt.puppet.com',
       release  => 'jammy',
       repos    => 'puppet-tools',
+      key      => {
+        'source' => 'https://apt.puppet.com/keyring.gpg',
+        'name'   => 'puppet.gpg',
+      },
       before   => Package['puppet-bolt'],
     }
   }


### PR DESCRIPTION
Their default key expired this year, we need to explicitly point to the key without expiration date.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
