### PR TITLE
refactor: Make the CLI helper a Puppet eXtension

### DIFF
--- a/lib/puppet_x/voxpupuli/aptly/cli_helper.rb
+++ b/lib/puppet_x/voxpupuli/aptly/cli_helper.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
+require 'puppet_x'
+
 # Aptly CLI helper
-module Aptly
+module PuppetX::Aptly
   # Define CLI helper error class
   class Error < StandardError
   end
@@ -104,17 +106,17 @@ module Aptly
 
       case from
       when 'mirror'
-        raise Aptly::Error, '`mirror` option should be defined' unless options[:mirror]
+        raise PuppetX::Aptly::Error, '`mirror` option should be defined' unless options[:mirror]
 
         cmd += ['from', 'mirror', options[:mirror]]
       when 'repo'
-        raise Aptly::Error, '`repo` option should be defined' unless options[:repo]
+        raise PuppetX::Aptly::Error, '`repo` option should be defined' unless options[:repo]
 
         cmd += ['from', 'repo', options[:repo]]
       when 'empty'
         cmd += %w[empty]
       else
-        raise Aptly::Error, '`from` argument must be one of: mirror, repo, empty'
+        raise PuppetX::Aptly::Error, '`from` argument must be one of: mirror, repo, empty'
       end
 
       execute(cmd)
@@ -235,14 +237,14 @@ module Aptly
       out, err, status = Open3.capture3(*cmd)
       return JSON.parse(out) if status.success?
 
-      raise Aptly::Error, "`#{cmd.join(' ')}` failed with status #{status.exitstatus}: #{err}"
+      raise PuppetX::Aptly::Error, "`#{cmd.join(' ')}` failed with status #{status.exitstatus}: #{err}"
     end
 
     def execute(cmd)
       _out, err, status = Open3.capture3(*cmd)
       return true if status.success?
 
-      raise Aptly::Error, "`#{cmd.join(' ')}` failed with status #{status.exitstatus}: #{err}"
+      raise PuppetX::Aptly::Error, "`#{cmd.join(' ')}` failed with status #{status.exitstatus}: #{err}"
     end
   end
 end

--- a/spec/tasks/mirror_create_spec.rb
+++ b/spec/tasks/mirror_create_spec.rb
@@ -8,7 +8,7 @@ describe AptlyMirrorCreateTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/mirror_drop_spec.rb
+++ b/spec/tasks/mirror_drop_spec.rb
@@ -8,7 +8,7 @@ describe AptlyMirrorDropTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/mirror_list_spec.rb
+++ b/spec/tasks/mirror_list_spec.rb
@@ -8,7 +8,7 @@ describe AptlyMirrorListTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/mirror_update_spec.rb
+++ b/spec/tasks/mirror_update_spec.rb
@@ -8,7 +8,7 @@ describe AptlyMirrorUpdateTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/publish_drop_spec.rb
+++ b/spec/tasks/publish_drop_spec.rb
@@ -8,7 +8,7 @@ describe AptlyPublishDropTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/publish_list_spec.rb
+++ b/spec/tasks/publish_list_spec.rb
@@ -8,7 +8,7 @@ describe AptlyPublishListTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/publish_repo_spec.rb
+++ b/spec/tasks/publish_repo_spec.rb
@@ -8,7 +8,7 @@ describe AptlyPublishRepoTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/publish_snapshot_spec.rb
+++ b/spec/tasks/publish_snapshot_spec.rb
@@ -8,7 +8,7 @@ describe AptlyPublishSnapshotTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/publish_switch_spec.rb
+++ b/spec/tasks/publish_switch_spec.rb
@@ -8,7 +8,7 @@ describe AptlyPublishSwitchTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/publish_update_spec.rb
+++ b/spec/tasks/publish_update_spec.rb
@@ -8,7 +8,7 @@ describe AptlyPublishUpdateTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/repo_add_spec.rb
+++ b/spec/tasks/repo_add_spec.rb
@@ -8,7 +8,7 @@ describe AptlyRepoAddTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/repo_create_spec.rb
+++ b/spec/tasks/repo_create_spec.rb
@@ -8,7 +8,7 @@ describe AptlyRepoCreateTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/repo_drop_spec.rb
+++ b/spec/tasks/repo_drop_spec.rb
@@ -8,7 +8,7 @@ describe AptlyRepoDropTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/repo_list_spec.rb
+++ b/spec/tasks/repo_list_spec.rb
@@ -8,7 +8,7 @@ describe AptlyRepoListTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/repo_remove_spec.rb
+++ b/spec/tasks/repo_remove_spec.rb
@@ -8,7 +8,7 @@ describe AptlyRepoRemoveTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/snapshot_create_spec.rb
+++ b/spec/tasks/snapshot_create_spec.rb
@@ -8,7 +8,7 @@ describe AptlySnapshotCreateTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/snapshot_drop_spec.rb
+++ b/spec/tasks/snapshot_drop_spec.rb
@@ -8,7 +8,7 @@ describe AptlySnapshotDropTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/tasks/snapshot_list_spec.rb
+++ b/spec/tasks/snapshot_list_spec.rb
@@ -8,7 +8,7 @@ describe AptlySnapshotListTask do
   let(:task) { described_class.new }
   let(:opts) { { cli_helper: aptly_helper } }
   let(:aptly_helper) do
-    helper = instance_double(Aptly::CliHelper)
+    helper = instance_double(PuppetX::Aptly::CliHelper)
     helper
   end
 

--- a/spec/unit/cli_helper_spec.rb
+++ b/spec/unit/cli_helper_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'cli_helper'
+require_relative '../../lib/puppet_x/voxpupuli/aptly/cli_helper'
 
-describe Aptly::CliHelper do
+describe PuppetX::Aptly::CliHelper do
   let(:capture3_success) do
     rc = instance_double(Process::Status)
     allow(rc).to receive(:success?).and_return(true)

--- a/tasks/mirror_create.json
+++ b/tasks/mirror_create.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "name": {

--- a/tasks/mirror_create.rb
+++ b/tasks/mirror_create.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Create the mirror
 class AptlyMirrorCreateTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @name = opts.delete(:name)
     @url = opts.delete(:url)
     @distribution = opts.delete(:distribution)

--- a/tasks/mirror_drop.json
+++ b/tasks/mirror_drop.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "name": {

--- a/tasks/mirror_drop.rb
+++ b/tasks/mirror_drop.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Drop the mirror
 class AptlyMirrorDropTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @name = opts.delete(:name)
     begin
       { mirror_drop: @cli_helper.mirror_drop(@name, opts) }

--- a/tasks/mirror_list.json
+++ b/tasks/mirror_list.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "config": {

--- a/tasks/mirror_list.rb
+++ b/tasks/mirror_list.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # List mirrors
 class AptlyMirrorListTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     begin
       { mirror_list: @cli_helper.mirror_list(opts) }
     rescue Aptly::Error => e

--- a/tasks/mirror_update.json
+++ b/tasks/mirror_update.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "name": {

--- a/tasks/mirror_update.rb
+++ b/tasks/mirror_update.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Update the mirror
 class AptlyMirrorUpdateTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @name = opts.delete(:name)
     begin
       { mirror_update: @cli_helper.mirror_update(@name, opts) }

--- a/tasks/publish_drop.json
+++ b/tasks/publish_drop.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "distribution": {

--- a/tasks/publish_drop.rb
+++ b/tasks/publish_drop.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Drop publishs
 class AptlyPublishDropTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @distribution = opts.delete(:distribution)
     @prefix = opts.delete(:prefix)
     begin

--- a/tasks/publish_list.json
+++ b/tasks/publish_list.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "config": {

--- a/tasks/publish_list.rb
+++ b/tasks/publish_list.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # List publishs
 class AptlyPublishListTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     begin
       { publish_list: @cli_helper.publish_list(opts) }
     rescue Aptly::Error => e

--- a/tasks/publish_repo.json
+++ b/tasks/publish_repo.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "name": {

--- a/tasks/publish_repo.rb
+++ b/tasks/publish_repo.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Repo the mirror
 class AptlyPublishRepoTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @name = opts.delete(:name)
     @prefix = opts.delete(:prefix)
     begin

--- a/tasks/publish_snapshot.json
+++ b/tasks/publish_snapshot.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "name": {

--- a/tasks/publish_snapshot.rb
+++ b/tasks/publish_snapshot.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Snapshot the mirror
 class AptlyPublishSnapshotTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @name = opts.delete(:name)
     @prefix = opts.delete(:prefix)
     begin

--- a/tasks/publish_switch.json
+++ b/tasks/publish_switch.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "distribution": {

--- a/tasks/publish_switch.rb
+++ b/tasks/publish_switch.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Switch the mirror
 class AptlyPublishSwitchTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @distribution = opts.delete(:distribution)
     @prefix = opts.delete(:prefix)
     @snapshot = opts.delete(:snapshot)

--- a/tasks/publish_update.json
+++ b/tasks/publish_update.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "distribution": {

--- a/tasks/publish_update.rb
+++ b/tasks/publish_update.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Update the mirror
 class AptlyPublishUpdateTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @distribution = opts.delete(:distribution)
     @prefix = opts.delete(:prefix)
     begin

--- a/tasks/repo_add.json
+++ b/tasks/repo_add.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "name": {

--- a/tasks/repo_add.rb
+++ b/tasks/repo_add.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Add package to local repo
 class AptlyRepoAddTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @name = opts.delete(:name)
     @package = opts.delete(:package)
     @directory = opts.delete(:directory)

--- a/tasks/repo_create.json
+++ b/tasks/repo_create.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "name": {

--- a/tasks/repo_create.rb
+++ b/tasks/repo_create.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Create the repo
 class AptlyRepoCreateTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @name = opts.delete(:name)
     begin
       { repo_create: @cli_helper.repo_create(@name, opts) }

--- a/tasks/repo_drop.json
+++ b/tasks/repo_drop.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "name": {

--- a/tasks/repo_drop.rb
+++ b/tasks/repo_drop.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Drop the repo
 class AptlyRepoDropTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @name = opts.delete(:name)
     begin
       { repo_drop: @cli_helper.repo_drop(@name, opts) }

--- a/tasks/repo_list.json
+++ b/tasks/repo_list.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "config": {

--- a/tasks/repo_list.rb
+++ b/tasks/repo_list.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # List repos
 class AptlyRepoListTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     begin
       { repo_list: @cli_helper.repo_list(opts) }
     rescue Aptly::Error => e

--- a/tasks/repo_remove.json
+++ b/tasks/repo_remove.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "name": {

--- a/tasks/repo_remove.rb
+++ b/tasks/repo_remove.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Remove package to local repo
 class AptlyRepoRemoveTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @name = opts.delete(:name)
     @package_query = opts.delete(:package_query)
 

--- a/tasks/snapshot_create.json
+++ b/tasks/snapshot_create.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "name": {

--- a/tasks/snapshot_create.rb
+++ b/tasks/snapshot_create.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Create the snapshot
 class AptlySnapshotCreateTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @name = opts.delete(:name)
     @from = opts.delete(:from)
     begin

--- a/tasks/snapshot_drop.json
+++ b/tasks/snapshot_drop.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "name": {

--- a/tasks/snapshot_drop.rb
+++ b/tasks/snapshot_drop.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # Drop the snapshot
 class AptlySnapshotDropTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     @name = opts.delete(:name)
     begin
       { snapshot_drop: @cli_helper.snapshot_drop(@name, opts) }

--- a/tasks/snapshot_list.json
+++ b/tasks/snapshot_list.json
@@ -5,7 +5,7 @@
   "input_method": "stdin",
   "files": [
     "ruby_task_helper/files/task_helper.rb",
-    "aptly/lib/cli_helper.rb"
+    "aptly/lib/puppet_x/voxpupuli/aptly/cli_helper.rb"
   ],
   "parameters": {
     "config": {

--- a/tasks/snapshot_list.rb
+++ b/tasks/snapshot_list.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/cli_helper'
+require_relative '../lib/puppet_x/voxpupuli/aptly/cli_helper'
 require_relative '../../ruby_task_helper/files/task_helper' unless Object.const_defined?('TaskHelper')
 
 # List snapshots
 class AptlySnapshotListTask < TaskHelper
   def task(opts = {})
-    @cli_helper ||= opts.delete(:cli_helper) || Aptly::CliHelper.new(opts)
+    @cli_helper ||= opts.delete(:cli_helper) || PuppetX::Aptly::CliHelper.new(opts)
     begin
       { snapshot_list: @cli_helper.snapshot_list(opts) }
     rescue Aptly::Error => e


### PR DESCRIPTION
No functional changes, just reshuffling files & renaming classes.