### PR TITLE
Add `aptly::serve`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Create an aptly repository to host local packages:
 aptly::repo { 'mylocalrepo': }
 ```
 
+Run the built-in static HTTP server (equivalent to `aptly serve`):
+
+```puppet
+include aptly
+
+class { 'aptly::serve':
+  listen => '0.0.0.0:8080',
+}
+```
+
 See the class and defined type documentation for advanced usage.
 
 ## License

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8,6 +8,7 @@
 
 * [`aptly`](#aptly): aptly is a swiss army knife for Debian repository management
 * [`aptly::api`](#aptly--api): Install and configure Aptly's API Service
+* [`aptly::serve`](#aptly--serve): Install and configure Aptly's static file server (aptly serve)
 
 ### Defined types
 
@@ -206,6 +207,60 @@ Data type: `Boolean`
 Enable concurrent use of command line (CLI) and HTTP APIs with the same Aptly root.
 
 Default value: `false`
+
+### <a name="aptly--serve"></a>`aptly::serve`
+
+Install and configure Aptly's static file server (aptly serve)
+
+#### Parameters
+
+The following parameters are available in the `aptly::serve` class:
+
+* [`ensure`](#-aptly--serve--ensure)
+* [`user`](#-aptly--serve--user)
+* [`group`](#-aptly--serve--group)
+* [`listen`](#-aptly--serve--listen)
+* [`config_file`](#-aptly--serve--config_file)
+
+##### <a name="-aptly--serve--ensure"></a>`ensure`
+
+Data type: `Enum['stopped','running']`
+
+Ensure to pass on to service type
+
+Default value: `running`
+
+##### <a name="-aptly--serve--user"></a>`user`
+
+Data type: `String[1]`
+
+User to run the service as.
+
+Default value: `'root'`
+
+##### <a name="-aptly--serve--group"></a>`group`
+
+Data type: `String[1]`
+
+Group to run the service as.
+
+Default value: `'root'`
+
+##### <a name="-aptly--serve--listen"></a>`listen`
+
+Data type: `Pattern['^([0-9.]*:[0-9]+$|unix:)']`
+
+What IP/port to listen on for HTTP requests.
+
+Default value: `':8080'`
+
+##### <a name="-aptly--serve--config_file"></a>`config_file`
+
+Data type: `Stdlib::Absolutepath`
+
+Absolute path to the Aptly configuration file.
+
+Default value: `'/etc/aptly.conf'`
 
 ## Defined types
 

--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -16,8 +16,14 @@ class aptly::api (
   Enum['none','log'] $log           = 'none',
   Boolean $enable_cli_and_http      = false,
 ) {
+  $description = 'Aptly-api'
+  $exec_start  = $enable_cli_and_http ? {
+    true    => "/usr/bin/aptly api serve -listen=${listen} -no-lock",
+    default => "/usr/bin/aptly api serve -listen=${listen}",
+  }
+
   systemd::unit_file { 'aptly-api.service':
-    content => template('aptly/etc/aptly-api.systemd.erb'),
+    content => template('aptly/etc/aptly.service.systemd.erb'),
     active  => $ensure == 'running',
     enable  => true,
   }

--- a/manifests/serve.pp
+++ b/manifests/serve.pp
@@ -1,0 +1,25 @@
+#
+# @summary Install and configure Aptly's static file server (aptly serve)
+#
+# @param ensure Ensure to pass on to service type
+# @param user User to run the service as.
+# @param group Group to run the service as.
+# @param listen What IP/port to listen on for HTTP requests.
+# @param config_file Absolute path to the Aptly configuration file.
+#
+class aptly::serve (
+  Enum['stopped','running'] $ensure           = running,
+  String[1] $user                             = 'root',
+  String[1] $group                            = 'root',
+  Pattern['^([0-9.]*:[0-9]+$|unix:)'] $listen = ':8080',
+  Stdlib::Absolutepath $config_file           = '/etc/aptly.conf',
+) {
+  $description = 'Aptly-serve'
+  $exec_start  = "/usr/bin/aptly serve -listen=${listen} -config=${config_file}"
+
+  systemd::unit_file { 'aptly-serve.service':
+    content => template('aptly/etc/aptly.service.systemd.erb'),
+    active  => $ensure == 'running',
+    enable  => $ensure == 'running',
+  }
+}

--- a/spec/classes/serve_spec.rb
+++ b/spec/classes/serve_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'aptly::serve' do
+  on_supported_os.each do |os, facts|
+    context "on #{os} with Facter #{facts[:facterversion]} and Puppet #{facts[:puppetversion]}" do
+      let(:facts) { facts }
+
+      context 'param defaults' do
+        it { is_expected.to contain_systemd__unit_file('aptly-serve.service') }
+
+        it do
+          is_expected.to contain_file('/etc/systemd/system/aptly-serve.service').
+            without_content(%r{^\s*author }).
+            with_content(%r{^User=root$}).
+            with_content(%r{^Group=root$}).
+            with_content(%r{^ExecStart=/usr/bin/aptly serve -listen=:8080 -config=/etc/aptly\.conf$}).
+            that_notifies('Service[aptly-serve.service]')
+        end
+
+        it do
+          is_expected.to contain_service('aptly-serve.service').
+            with_ensure(true).
+            with_enable(true)
+        end
+      end
+
+      describe 'ensure' do
+        context 'present (default)' do
+          it { is_expected.to contain_service('aptly-serve.service').with_ensure(true) }
+        end
+
+        context 'stopped' do
+          let(:params) { { ensure: 'stopped' } }
+
+          it { is_expected.to contain_service('aptly-serve.service').with_ensure(false) }
+          it { is_expected.to contain_service('aptly-serve.service').with_enable(false) }
+        end
+      end
+
+      describe 'user' do
+        context 'custom' do
+          let(:params) { { user: 'yolo' } }
+
+          it { is_expected.to contain_file('/etc/systemd/system/aptly-serve.service').with_content(%r{^User=yolo$}) }
+        end
+      end
+
+      describe 'group' do
+        context 'custom' do
+          let(:params) { { group: 'yolo' } }
+
+          it { is_expected.to contain_file('/etc/systemd/system/aptly-serve.service').with_content(%r{^Group=yolo$}) }
+        end
+      end
+
+      describe 'listen' do
+        context 'custom' do
+          let(:params) { { listen: '127.0.0.1:9090' } }
+
+          it { is_expected.to contain_file('/etc/systemd/system/aptly-serve.service').with_content(%r{^ExecStart=/usr/bin/aptly serve -listen=127\.0\.0\.1:9090 -config=/etc/aptly\.conf$}) }
+        end
+      end
+
+      describe 'config_file' do
+        context 'custom' do
+          let(:params) { { config_file: '/etc/aptly/aptly.conf' } }
+
+          it { is_expected.to contain_file('/etc/systemd/system/aptly-serve.service').with_content(%r{^ExecStart=/usr/bin/aptly serve -listen=:8080 -config=/etc/aptly/aptly\.conf$}) }
+        end
+      end
+    end
+  end
+end

--- a/templates/etc/aptly.service.systemd.erb
+++ b/templates/etc/aptly.service.systemd.erb
@@ -1,12 +1,12 @@
 [Unit]
-Description=Aptly-api
+Description=<%= @description %>
 Wants=basic.target
 After=basic.target network.target
 
 [Service]
 User=<%= @user %>
 Group=<%= @group %>
-ExecStart=/usr/bin/aptly api serve -listen=<%= @listen %><% if @enable_cli_and_http %> -no-lock<% end %>
+ExecStart=<%= @exec_start %>
 
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process


### PR DESCRIPTION
#### Pull Request (PR) description

Add `aptly::serve`, by making the existing `aptly::api` template reusable and using that for both.

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-aptly/issues/45
