### PR TITLE
Add openbolt to test gem group

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,3 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
 {
 	"name": "VoxBox",
 	"image": "ghcr.io/voxpupuli/voxbox:latest"

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,9 @@
 ---
+Gemfile:
+  optional:
+    ':test':
+      - gem: 'openbolt'
+        version: '~> 5'
 spec/spec_helper_acceptance.rb:
   unmanaged: false
 .puppet-lint.rc:

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 group :test do
   gem 'voxpupuli-test', '~> 13.0',  :require => false
   gem 'puppet_metadata', '~> 6.0',  :require => false
+  gem 'openbolt', '~> 5',           :require => false
 end
 
 group :development do


### PR DESCRIPTION
This MR adds `openbolt` gem to the test gem group to allow BoltSpec usage in unit tests.