### PR TITLE
Do not leak configuration secrets

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -78,6 +78,7 @@ The following parameters are available in the `aptly` class:
 * [`repo`](#-aptly--repo)
 * [`key_server`](#-aptly--key_server)
 * [`user`](#-aptly--user)
+* [`config_group`](#-aptly--config_group)
 * [`aptly_repos`](#-aptly--aptly_repos)
 * [`aptly_mirrors`](#-aptly--aptly_mirrors)
 
@@ -136,6 +137,14 @@ Data type: `String`
 The user to use when performing an aptly command
 
 Default value: `'root'`
+
+##### <a name="-aptly--config_group"></a>`config_group`
+
+Data type: `String[1]`
+
+The the group ownership of the configuration file. Defaults to $user name.
+
+Default value: `$user`
 
 ##### <a name="-aptly--aptly_repos"></a>`aptly_repos`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -78,6 +78,9 @@ The following parameters are available in the `aptly` class:
 * [`repo`](#-aptly--repo)
 * [`key_server`](#-aptly--key_server)
 * [`user`](#-aptly--user)
+* [`config_group`](#-aptly--config_group)
+* [`config_owner`](#-aptly--config_owner)
+* [`config_mode`](#-aptly--config_mode)
 * [`aptly_repos`](#-aptly--aptly_repos)
 * [`aptly_mirrors`](#-aptly--aptly_mirrors)
 
@@ -136,6 +139,30 @@ Data type: `String`
 The user to use when performing an aptly command
 
 Default value: `'root'`
+
+##### <a name="-aptly--config_group"></a>`config_group`
+
+Data type: `String[1]`
+
+The the group ownership of the configuration file. Defaults to $user name.
+
+Default value: `$user`
+
+##### <a name="-aptly--config_owner"></a>`config_owner`
+
+Data type: `String[1]`
+
+The the user ownership of the configuration file. Defaults to $user name.
+
+Default value: `$user`
+
+##### <a name="-aptly--config_mode"></a>`config_mode`
+
+Data type: `String[1]`
+
+The UNIX file permission for the configuration file. Defaults to '0440'
+
+Default value: `'0440'`
 
 ##### <a name="-aptly--aptly_repos"></a>`aptly_repos`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@
 # @param repo Whether to configure an apt::source for `repo.aptly.info`. You might want to disable this when you've mirrored that yourself.
 # @param key_server Key server to use when `$repo` is true.
 # @param user The user to use when performing an aptly command
+# @param config_group The the group ownership of the configuration file. Defaults to $user name.
 # @param aptly_repos Hash of aptly repos which is passed to aptly::repo
 # @param aptly_mirrors Hash of aptly mirrors which is passed to aptly::mirror
 #
@@ -19,6 +20,7 @@ class aptly (
   Boolean $repo                     = true,
   Stdlib::Fqdn $key_server          = 'keyserver.ubuntu.com',
   String $user                      = 'root',
+  String[1] $config_group           = $user,
   Hash $aptly_repos                 = {},
   Hash $aptly_mirrors               = {},
 ) {
@@ -45,8 +47,12 @@ class aptly (
   }
 
   file { $config_file:
-    ensure  => file,
-    content => $config_file_contents,
+    ensure    => file,
+    content   => $config_file_contents,
+    owner     => $user,
+    group     => $config_group,
+    mode      => '0440',
+    show_diff => false,
   }
 
   $aptly_cmd = "/usr/bin/aptly -config ${config_file}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,9 @@
 # @param repo Whether to configure an apt::source for `repo.aptly.info`. You might want to disable this when you've mirrored that yourself.
 # @param key_server Key server to use when `$repo` is true.
 # @param user The user to use when performing an aptly command
+# @param config_group The the group ownership of the configuration file. Defaults to $user name.
+# @param config_owner The the user ownership of the configuration file. Defaults to $user name.
+# @param config_mode The UNIX file permission for the configuration file. Defaults to '0440'
 # @param aptly_repos Hash of aptly repos which is passed to aptly::repo
 # @param aptly_mirrors Hash of aptly mirrors which is passed to aptly::mirror
 #
@@ -19,6 +22,9 @@ class aptly (
   Boolean $repo                     = true,
   Stdlib::Fqdn $key_server          = 'keyserver.ubuntu.com',
   String $user                      = 'root',
+  String[1] $config_group           = $user,
+  String[1] $config_owner           = $user,
+  String[1] $config_mode            = '0440',
   Hash $aptly_repos                 = {},
   Hash $aptly_mirrors               = {},
 ) {
@@ -45,8 +51,12 @@ class aptly (
   }
 
   file { $config_file:
-    ensure  => file,
-    content => $config_file_contents,
+    ensure    => file,
+    content   => $config_file_contents,
+    owner     => $config_owner,
+    group     => $config_group,
+    mode      => $config_mode,
+    show_diff => false,
   }
 
   $aptly_cmd = "/usr/bin/aptly -config ${config_file}"

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -39,7 +39,14 @@ describe 'aptly' do
         context 'custom config path' do
           let(:params) { { config_file: '/etc/aptly/aptly.conf' } }
 
-          it { is_expected.to contain_file('/etc/aptly/aptly.conf') }
+          it {
+            is_expected.to contain_file('/etc/aptly/aptly.conf').with({
+                                                                        owner: 'root',
+                                                                        group: 'root',
+                                                                        mode: '0440',
+                                                                        show_diff: false,
+                                                                      })
+          }
         end
       end
 


### PR DESCRIPTION
There are cases where the configuration will contain sensitive
information, such as when a Swift or S3 publish endpoint are defined.
Thus the configuration file should not be global-read.

In addition, some users of this module, to remain unnamed, may have had
these secrets dumped into the logging pipeline due to the file change in
Puppet displaying a diff. Best to not do that.

Note for reviewers: The first commit is unrelated, just wanted tests passing locally. Edit: Or not.