### PR TITLE
Add multi_dist option to publish tasks

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1074,6 +1074,12 @@ Data type: `Optional[Boolean]`
 
 When processing dependencies, follow Suggests
 
+##### `multi_dist`
+
+Data type: `Optional[Boolean]`
+
+Allow multiple packages with the same filename in different distributions
+
 ### <a name="publish_show"></a>`publish_show`
 
 Shows details of published repository
@@ -1258,6 +1264,12 @@ Data type: `Optional[Boolean]`
 
 When processing dependencies, follow Suggests
 
+##### `multi_dist`
+
+Data type: `Optional[Boolean]`
+
+Allow multiple packages with the same filename in different distributions
+
 ### <a name="publish_switch"></a>`publish_switch`
 
 Update published repository by switching to new snapshot
@@ -1386,6 +1398,12 @@ Data type: `Optional[Boolean]`
 
 When processing dependencies, follow Suggests
 
+##### `multi_dist`
+
+Data type: `Optional[Boolean]`
+
+Allow multiple packages with the same filename in different distributions
+
 ### <a name="publish_update"></a>`publish_update`
 
 Update published local repository
@@ -1501,6 +1519,12 @@ When processing dependencies, follow from binary to Source packages
 Data type: `Optional[Boolean]`
 
 When processing dependencies, follow Suggests
+
+##### `multi_dist`
+
+Data type: `Optional[Boolean]`
+
+Allow multiple packages with the same filename in different distributions
 
 ### <a name="repo_add"></a>`repo_add`
 

--- a/lib/puppet_x/voxpupuli/aptly/cli_helper.rb
+++ b/lib/puppet_x/voxpupuli/aptly/cli_helper.rb
@@ -213,6 +213,7 @@ module PuppetX
         cmd << "-gpg-key=#{options[:gpg_key]}" if options[:gpg_key]
         cmd += Array(options[:keyring]).map { |x| "-keyring=#{x}" }
         cmd << "-label=#{options[:label]}" if options[:label]
+        cmd << '-multi-dist' if options[:multi_dist]
         cmd << "-notautomatic=#{options[:not_automatic]}" if options[:not_automatic]
         cmd << "-origin=#{options[:origin]}" if options[:origin]
         cmd << "-passphrase-file=#{options[:passphrase_file]}" if options[:passphrase_file]
@@ -238,6 +239,7 @@ module PuppetX
         cmd << '-force-overwrite' if options[:force_overwrite]
         cmd << "-gpg-key=#{options[:gpg_key]}" if options[:gpg_key]
         cmd += Array(options[:keyring]).map { |x| "-keyring=#{x}" }
+        cmd << '-multi-dist' if options[:multi_dist]
         cmd << "-passphrase-file=#{options[:passphrase_file]}" if options[:passphrase_file]
         cmd << "-secret-keyring=#{options[:secret_keyring]}" if options[:secret_keyring]
         cmd << '-skip-bz2' if options[:skip_bz2]

--- a/spec/unit/cli_helper_spec.rb
+++ b/spec/unit/cli_helper_spec.rb
@@ -394,6 +394,7 @@ describe PuppetX::Aptly::CliHelper do
           gpg_key: 'ABCDEFGH',
           keyring: '/home/aptly/keyring.gpg',
           label: 'Debian-Security',
+          multi_dist: true,
           not_automatic: 'no',
           origin: 'Debian',
           passphrase_file: '/home/aptly/passphrase.txt',
@@ -412,7 +413,7 @@ describe PuppetX::Aptly::CliHelper do
         -dep-follow-suggests -acquire-by-hash -batch -butautomaticupgrades=no
         -component=main,contrib,non-free,non-free-firmware
         -distribution=bookworm -force-overwrite -gpg-key=ABCDEFGH
-        -keyring=/home/aptly/keyring.gpg -label=Debian-Security
+        -keyring=/home/aptly/keyring.gpg -label=Debian-Security -multi-dist
         -notautomatic=no -origin=Debian
         -passphrase-file=/home/aptly/passphrase.txt
         -secret-keyring=/home/aptly/secret-keyring.gpg -skip-bz2 -skip-contents
@@ -448,6 +449,7 @@ describe PuppetX::Aptly::CliHelper do
           gpg_key: 'ABCDEFGH',
           keyring: '/home/aptly/keyring.gpg',
           label: 'Example-Repo',
+          multi_dist: true,
           not_automatic: 'no',
           origin: 'example.com',
           passphrase_file: '/home/aptly/passphrase.txt',
@@ -465,8 +467,9 @@ describe PuppetX::Aptly::CliHelper do
         -dep-follow-recommends -dep-follow-source -dep-follow-suggests
         -acquire-by-hash -batch -butautomaticupgrades=no -component=main
         -distribution=bookworm -force-overwrite -gpg-key=ABCDEFGH
-        -keyring=/home/aptly/keyring.gpg -label=Example-Repo -notautomatic=no
-        -origin=example.com -passphrase-file=/home/aptly/passphrase.txt
+        -keyring=/home/aptly/keyring.gpg -label=Example-Repo -multi-dist
+        -notautomatic=no -origin=example.com
+        -passphrase-file=/home/aptly/passphrase.txt
         -secret-keyring=/home/aptly/secret-keyring.gpg -skip-bz2 -skip-contents
         -skip-signing -suite=bookworm example-repo current/example-repo
       ]
@@ -501,6 +504,7 @@ describe PuppetX::Aptly::CliHelper do
           force_overwrite: true,
           gpg_key: 'ABCDEFGH',
           keyring: '/home/aptly/keyring.gpg',
+          multi_dist: true,
           passphrase_file: '/home/aptly/passphrase.txt',
           secret_keyring: '/home/aptly/secret-keyring.gpg',
           skip_bz2: true,
@@ -515,7 +519,7 @@ describe PuppetX::Aptly::CliHelper do
         -dep-follow-all-variants -dep-follow-recommends -dep-follow-source
         -dep-follow-suggests -batch
         -component=main,contrib,non-free,non-free-firmware -force-overwrite
-        -gpg-key=ABCDEFGH -keyring=/home/aptly/keyring.gpg
+        -gpg-key=ABCDEFGH -keyring=/home/aptly/keyring.gpg -multi-dist
         -passphrase-file=/home/aptly/passphrase.txt
         -secret-keyring=/home/aptly/secret-keyring.gpg -skip-bz2 -skip-contents
         -skip-signing bookworm current/debian-security
@@ -547,6 +551,7 @@ describe PuppetX::Aptly::CliHelper do
           force_overwrite: true,
           gpg_key: 'ABCDEFGH',
           keyring: '/home/aptly/keyring.gpg',
+          multi_dist: true,
           passphrase_file: '/home/aptly/passphrase.txt',
           secret_keyring: '/home/aptly/secret-keyring.gpg',
           skip_bz2: true,
@@ -560,7 +565,7 @@ describe PuppetX::Aptly::CliHelper do
         aptly publish update -architectures=amd64
         -dep-follow-all-variants -dep-follow-recommends -dep-follow-source
         -dep-follow-suggests -batch -force-overwrite -gpg-key=ABCDEFGH
-        -keyring=/home/aptly/keyring.gpg
+        -keyring=/home/aptly/keyring.gpg -multi-dist
         -passphrase-file=/home/aptly/passphrase.txt
         -secret-keyring=/home/aptly/secret-keyring.gpg -skip-bz2 -skip-contents
         -skip-signing bookworm current/example-repo

--- a/tasks/publish_repo.json
+++ b/tasks/publish_repo.json
@@ -113,6 +113,10 @@
     "dep_follow_suggests": {
       "description": "When processing dependencies, follow Suggests",
       "type": "Optional[Boolean]"
+    },
+    "multi_dist": {
+      "description": "Allow multiple packages with the same filename in different distributions",
+      "type": "Optional[Boolean]"
     }
   }
 }

--- a/tasks/publish_snapshot.json
+++ b/tasks/publish_snapshot.json
@@ -113,6 +113,10 @@
     "dep_follow_suggests": {
       "description": "When processing dependencies, follow Suggests",
       "type": "Optional[Boolean]"
+    },
+    "multi_dist": {
+      "description": "Allow multiple packages with the same filename in different distributions",
+      "type": "Optional[Boolean]"
     }
   }
 }

--- a/tasks/publish_switch.json
+++ b/tasks/publish_switch.json
@@ -93,6 +93,10 @@
     "dep_follow_suggests": {
       "description": "When processing dependencies, follow Suggests",
       "type": "Optional[Boolean]"
+    },
+    "multi_dist": {
+      "description": "Allow multiple packages with the same filename in different distributions",
+      "type": "Optional[Boolean]"
     }
   }
 }

--- a/tasks/publish_update.json
+++ b/tasks/publish_update.json
@@ -85,6 +85,10 @@
     "dep_follow_suggests": {
       "description": "When processing dependencies, follow Suggests",
       "type": "Optional[Boolean]"
+    },
+    "multi_dist": {
+      "description": "Allow multiple packages with the same filename in different distributions",
+      "type": "Optional[Boolean]"
     }
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds `multi_dist` option to aptly publish-related tasks. This option allows to have multiple packages with the same filename in different distributions.

#### This Pull Request (PR) fixes the following issues

Fixes #87 