### PR TITLE
Allow multiple GPG signing keys

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1037,9 +1037,9 @@ Overwrite files in package pool in case of mismatch
 
 ##### `gpg_key`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Variant[String[1],Array[String[1]]]]`
 
-GPG key ID to use when signing the release
+GPG key ID (or list of IDs) to use when signing the release
 
 ##### `keyring`
 
@@ -1227,9 +1227,9 @@ Overwrite files in package pool in case of mismatch
 
 ##### `gpg_key`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Variant[String[1],Array[String[1]]]]`
 
-GPG key ID to use when signing the release
+GPG key ID (or list of IDs) to use when signing the release
 
 ##### `keyring`
 
@@ -1379,9 +1379,9 @@ Overwrite files in package pool in case of mismatch
 
 ##### `gpg_key`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Variant[String[1],Array[String[1]]]]`
 
-GPG key ID to use when signing the release
+GPG key ID (or list of IDs) to use when signing the release
 
 ##### `keyring`
 
@@ -1501,9 +1501,9 @@ Overwrite files in package pool in case of mismatch
 
 ##### `gpg_key`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Variant[String[1],Array[String[1]]]]`
 
-GPG key ID to use when signing the release
+GPG key ID (or list of IDs) to use when signing the release
 
 ##### `keyring`
 

--- a/lib/puppet_x/voxpupuli/aptly/cli_helper.rb
+++ b/lib/puppet_x/voxpupuli/aptly/cli_helper.rb
@@ -215,7 +215,7 @@ module PuppetX
         cmd << "-component=#{Array(options[:component]).join(',')}" if options[:component]
         cmd << "-distribution=#{options[:distribution]}" if options[:distribution]
         cmd << '-force-overwrite' if options[:force_overwrite]
-        cmd << "-gpg-key=#{options[:gpg_key]}" if options[:gpg_key]
+        cmd += Array(options[:gpg_key]).map { |x| "-gpg-key=#{x}" }
         cmd += Array(options[:keyring]).map { |x| "-keyring=#{x}" }
         cmd << "-label=#{options[:label]}" if options[:label]
         cmd << '-multi-dist' if options[:multi_dist]
@@ -242,7 +242,7 @@ module PuppetX
         cmd << "-component=#{Array(options[:component]).join(',')}" if options[:component] && how == 'switch'
 
         cmd << '-force-overwrite' if options[:force_overwrite]
-        cmd << "-gpg-key=#{options[:gpg_key]}" if options[:gpg_key]
+        cmd += Array(options[:gpg_key]).map { |x| "-gpg-key=#{x}" }
         cmd += Array(options[:keyring]).map { |x| "-keyring=#{x}" }
         cmd << '-multi-dist' if options[:multi_dist]
         cmd << "-passphrase-file=#{options[:passphrase_file]}" if options[:passphrase_file]

--- a/spec/unit/cli_helper_spec.rb
+++ b/spec/unit/cli_helper_spec.rb
@@ -399,7 +399,7 @@ describe PuppetX::Aptly::CliHelper do
           component: %w[main contrib non-free non-free-firmware],
           distribution: 'bookworm',
           force_overwrite: true,
-          gpg_key: 'ABCDEFGH',
+          gpg_key: %w[ABCDEFGH IJKLMNOP],
           keyring: '/home/aptly/keyring.gpg',
           label: 'Debian-Security',
           multi_dist: true,
@@ -420,7 +420,7 @@ describe PuppetX::Aptly::CliHelper do
         -dep-follow-all-variants -dep-follow-recommends -dep-follow-source
         -dep-follow-suggests -acquire-by-hash -batch -butautomaticupgrades=no
         -component=main,contrib,non-free,non-free-firmware
-        -distribution=bookworm -force-overwrite -gpg-key=ABCDEFGH
+        -distribution=bookworm -force-overwrite -gpg-key=ABCDEFGH -gpg-key=IJKLMNOP
         -keyring=/home/aptly/keyring.gpg -label=Debian-Security -multi-dist
         -notautomatic=no -origin=Debian
         -passphrase-file=/home/aptly/passphrase.txt
@@ -510,7 +510,7 @@ describe PuppetX::Aptly::CliHelper do
           batch: true,
           component: %w[main contrib non-free non-free-firmware],
           force_overwrite: true,
-          gpg_key: 'ABCDEFGH',
+          gpg_key: %w[ABCDEFGH IJKLMNOP],
           keyring: '/home/aptly/keyring.gpg',
           multi_dist: true,
           passphrase_file: '/home/aptly/passphrase.txt',
@@ -527,7 +527,7 @@ describe PuppetX::Aptly::CliHelper do
         -dep-follow-all-variants -dep-follow-recommends -dep-follow-source
         -dep-follow-suggests -batch
         -component=main,contrib,non-free,non-free-firmware -force-overwrite
-        -gpg-key=ABCDEFGH -keyring=/home/aptly/keyring.gpg -multi-dist
+        -gpg-key=ABCDEFGH -gpg-key=IJKLMNOP -keyring=/home/aptly/keyring.gpg -multi-dist
         -passphrase-file=/home/aptly/passphrase.txt
         -secret-keyring=/home/aptly/secret-keyring.gpg -skip-bz2 -skip-contents
         -skip-signing bookworm current/debian-security

--- a/tasks/publish_repo.json
+++ b/tasks/publish_repo.json
@@ -47,8 +47,8 @@
       "type": "Optional[Boolean]"
     },
     "gpg_key": {
-      "description": "GPG key ID to use when signing the release",
-      "type": "Optional[String[1]]"
+      "description": "GPG key ID (or list of IDs) to use when signing the release",
+      "type": "Optional[Variant[String[1],Array[String[1]]]]"
     },
     "keyring": {
       "description": "GPG keyring(s) to use (instead of default)",

--- a/tasks/publish_snapshot.json
+++ b/tasks/publish_snapshot.json
@@ -47,8 +47,8 @@
       "type": "Optional[Boolean]"
     },
     "gpg_key": {
-      "description": "GPG key ID to use when signing the release",
-      "type": "Optional[String[1]]"
+      "description": "GPG key ID (or list of IDs) to use when signing the release",
+      "type": "Optional[Variant[String[1],Array[String[1]]]]"
     },
     "keyring": {
       "description": "GPG keyring(s) to use (instead of default)",

--- a/tasks/publish_switch.json
+++ b/tasks/publish_switch.json
@@ -39,8 +39,8 @@
       "type": "Optional[Boolean]"
     },
     "gpg_key": {
-      "description": "GPG key ID to use when signing the release",
-      "type": "Optional[String[1]]"
+      "description": "GPG key ID (or list of IDs) to use when signing the release",
+      "type": "Optional[Variant[String[1],Array[String[1]]]]"
     },
     "keyring": {
       "description": "GPG keyring(s) to use (instead of default)",

--- a/tasks/publish_update.json
+++ b/tasks/publish_update.json
@@ -31,8 +31,8 @@
       "type": "Optional[Boolean]"
     },
     "gpg_key": {
-      "description": "GPG key ID to use when signing the release",
-      "type": "Optional[String[1]]"
+      "description": "GPG key ID (or list of IDs) to use when signing the release",
+      "type": "Optional[Variant[String[1],Array[String[1]]]]"
     },
     "keyring": {
       "description": "GPG keyring(s) to use (instead of default)",


### PR DESCRIPTION
#### Pull Request (PR) description

Allows the publish tasks to accept either one GPG key or a list. Lists are passed to Aptly as repeated `-gpg-key` flags, while the existing string input still works.

#### This Pull Request (PR) fixes the following issues

Fixes #92