### PR TITLE
Add latest option to mirror update task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 /coverage/
 /log/
 /.idea/
-.DS_Store
 /.dependencies/
 /.librarian/
 /Puppetfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /coverage/
 /log/
 /.idea/
+.DS_Store
 /.dependencies/
 /.librarian/
 /Puppetfile.lock

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -879,6 +879,12 @@ Data type: `Optional[Variant[Stdlib::Absolutepath,Array[Stdlib::Absolutepath]]]`
 
 GPG keyring(s) to use when verifying Release file
 
+##### `latest`
+
+Data type: `Optional[Boolean]`
+
+Download only latest version of each package (per architecture)
+
 ##### `max_tries`
 
 Data type: `Optional[Integer[0]]`

--- a/lib/puppet_x/voxpupuli/aptly/cli_helper.rb
+++ b/lib/puppet_x/voxpupuli/aptly/cli_helper.rb
@@ -50,6 +50,7 @@ module PuppetX
         cmd << '-ignore-checksums' if options[:ignore_checksums]
         cmd << '-ignore-signatures' if options[:ignore_signatures]
         cmd += Array(options[:keyring]).map { |x| "-keyring=#{x}" }
+        cmd << '-latest' if options[:latest]
         cmd << "-max-tries=#{options[:max_tries]}" if options[:max_tries]
         cmd << '-skip-existing-packages' if options[:skip_existing_packages]
         cmd << name

--- a/spec/tasks/mirror_spec.rb
+++ b/spec/tasks/mirror_spec.rb
@@ -66,7 +66,7 @@ describe AptlyMirrorTask do
   end
 
   describe 'mirror_update' do
-    let(:opts) { super().merge(name: 'test', architectures: %w[amd64 arm64]) }
+    let(:opts) { super().merge(name: 'test', architectures: %w[amd64 arm64], latest: true) }
 
     it 'updates the mirror' do
       allow(PuppetX::Aptly::CliHelper).to receive(method_name).with(opts[:name], opts).and_return(true)

--- a/spec/unit/cli_helper_spec.rb
+++ b/spec/unit/cli_helper_spec.rb
@@ -112,6 +112,7 @@ describe PuppetX::Aptly::CliHelper do
           ignore_checksums: true,
           ignore_signatures: true,
           keyring: ['/home/aptly/example_keyring1.gpg', '/home/aptly/example_keyring2.gpg'],
+          latest: true,
           max_tries: 5,
           skip_existing_packages: true,
         }.merge(non_aptly_options),
@@ -123,7 +124,7 @@ describe PuppetX::Aptly::CliHelper do
         -dep-follow-recommends -dep-follow-source -dep-follow-suggests
         -download-limit=100 -downloader=default -force -ignore-checksums
         -ignore-signatures -keyring=/home/aptly/example_keyring1.gpg
-        -keyring=/home/aptly/example_keyring2.gpg -max-tries=5
+        -keyring=/home/aptly/example_keyring2.gpg -latest -max-tries=5
         -skip-existing-packages bookworm-main
       ]
     end
@@ -131,6 +132,16 @@ describe PuppetX::Aptly::CliHelper do
     specify do
       cli_helper.mirror_update(*args)
       expect(Open3).to have_received(:capture3).with(*cmd).once
+    end
+
+    context 'without latest' do
+      let(:args) { ['bookworm-main', non_aptly_options] }
+      let(:cmd) { [aptly_environment] + %w[aptly.sh mirror update bookworm-main] }
+
+      specify do
+        cli_helper.mirror_update(*args)
+        expect(Open3).to have_received(:capture3).with(*cmd).once
+      end
     end
   end
 

--- a/tasks/mirror_update.json
+++ b/tasks/mirror_update.json
@@ -42,6 +42,10 @@
       "description": "GPG keyring(s) to use when verifying Release file",
       "type": "Optional[Variant[Stdlib::Absolutepath,Array[Stdlib::Absolutepath]]]"
     },
+    "latest": {
+      "description": "Download only latest version of each package (per architecture)",
+      "type": "Optional[Boolean]"
+    },
     "max_tries": {
       "description": "Max download tries till process fails with download error",
       "type": "Optional[Integer[0]]"


### PR DESCRIPTION
## Summary

- expose an optional `latest` Boolean on the `mirror_update` task
- pass `-latest` to aptly only when the option is enabled
- cover both enabled and omitted behavior, including task pass-through
- regenerate `REFERENCE.md` with Puppet Strings

Fixes #91

## Verification

- [x] `bundle exec rspec spec/unit/cli_helper_spec.rb spec/tasks/mirror_spec.rb` — 34 examples, 0 failures
- [x] `bundle exec rspec spec/tasks spec/unit/cli_helper_spec.rb` — 59 examples, 0 failures
- [x] `bundle exec rake validate lint check rubocop`
- [x] `git diff --check`
- [x] Upstream CI — 10/10 checks passed, including static validation, the test suite, and all supported OpenVox platform jobs

## AI assistance

OpenAI Codex assisted with repository analysis, implementation, regression coverage, and PR preparation. The resulting diff was inspected and the checks listed above were executed before submission.
